### PR TITLE
:children_crossing: Improve the redirection after an entity deletion

### DIFF
--- a/netbox_docker_plugin/views/container.py
+++ b/netbox_docker_plugin/views/container.py
@@ -81,6 +81,7 @@ class ContainerBulkDeleteView(generic.BulkDeleteView):
 class ContainerDeleteView(generic.ObjectDeleteView):
     """Container delete view definition"""
 
+    default_return_url = "plugins:netbox_docker_plugin:container_list"
     queryset = Container.objects.all()
 
 

--- a/netbox_docker_plugin/views/host.py
+++ b/netbox_docker_plugin/views/host.py
@@ -109,6 +109,7 @@ class HostBulkImportView(generic.BulkImportView):
 class HostDeleteView(generic.ObjectDeleteView):
     """Host delete view definition"""
 
+    default_return_url = "plugins:netbox_docker_plugin:host_list"
     queryset = Host.objects.all()
 
 

--- a/netbox_docker_plugin/views/image.py
+++ b/netbox_docker_plugin/views/image.py
@@ -51,6 +51,7 @@ class ImageBulkImportView(generic.BulkImportView):
 class ImageDeleteView(generic.ObjectDeleteView):
     """Image delete view definition"""
 
+    default_return_url = "plugins:netbox_docker_plugin:image_list"
     queryset = Image.objects.all()
 
 

--- a/netbox_docker_plugin/views/network.py
+++ b/netbox_docker_plugin/views/network.py
@@ -50,6 +50,7 @@ class NetworkBulkImportView(generic.BulkImportView):
 class NetworkDeleteView(generic.ObjectDeleteView):
     """Network delete view definition"""
 
+    default_return_url = "plugins:netbox_docker_plugin:network_list"
     queryset = Network.objects.all()
 
 

--- a/netbox_docker_plugin/views/volume.py
+++ b/netbox_docker_plugin/views/volume.py
@@ -50,4 +50,5 @@ class VolumeBulkDeleteView(generic.BulkDeleteView):
 class VolumeDeleteView(generic.ObjectDeleteView):
     """Volume delete view definition"""
 
+    default_return_url = "plugins:netbox_docker_plugin:volume_list"
     queryset = Volume.objects.all()


### PR DESCRIPTION
When an entity is deleted, we fix redirection to entities listing.