### PR TITLE
:card_file_box: Add `read_only` field to `Mount` and `Bind` models

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -10,7 +10,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "1.6.2"
+    version = "1.7.0"
     base_url = "docker"
     author= "Vincent Simonin"
     author_email= "vincent@saashup.com"

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -159,6 +159,7 @@ class NestedMountSerializer(WritableNestedSerializer):
         fields = (
             "id",
             "source",
+            "read_only",
         )
 
 
@@ -340,6 +341,7 @@ class MountSerializer(serializers.ModelSerializer):
         fields = (
             "source",
             "volume",
+            "read_only",
         )
 
 
@@ -353,6 +355,7 @@ class BindSerializer(serializers.ModelSerializer):
         fields = (
             "host_path",
             "container_path",
+            "read_only",
         )
 
 

--- a/netbox_docker_plugin/forms/bind.py
+++ b/netbox_docker_plugin/forms/bind.py
@@ -27,11 +27,13 @@ class BindForm(BootstrapMixin, forms.ModelForm):
             "container",
             "host_path",
             "container_path",
+            "read_only",
         )
         labels = {
             "container": "Container",
             "host_path": "Path to mount on host",
             "container_path": "Mountpoint in container",
+            "read_only": "Mount as read-only within the container",
         }
 
 

--- a/netbox_docker_plugin/forms/mount.py
+++ b/netbox_docker_plugin/forms/mount.py
@@ -31,11 +31,13 @@ class MountForm(BootstrapMixin, forms.ModelForm):
             "container",
             "source",
             "volume",
+            "read_only",
         )
         labels = {
             "container": "Container",
             "source": "Source directory",
             "volume": "Volume",
+            "read_only": "Mount as read-only within the container",
         }
 
 

--- a/netbox_docker_plugin/migrations/0028_mount_and_bind_read_only.py
+++ b/netbox_docker_plugin/migrations/0028_mount_and_bind_read_only.py
@@ -1,0 +1,25 @@
+# pylint: disable=C0103
+"""Migration file"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration file"""
+
+    dependencies = [
+        ("netbox_docker_plugin", "0027_container_restart_policy"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mount",
+            name="read_only",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="bind",
+            name="read_only",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/netbox_docker_plugin/models/container.py
+++ b/netbox_docker_plugin/models/container.py
@@ -301,6 +301,9 @@ class Mount(models.Model):
             MaxLengthValidator(limit_value=1024),
         ],
     )
+    read_only = models.BooleanField(
+        default=False,
+    )
 
     class Meta:
         """Mount Model Meta Class"""
@@ -348,6 +351,9 @@ class Bind(models.Model):
             MinLengthValidator(limit_value=1),
             MaxLengthValidator(limit_value=1024),
         ],
+    )
+    read_only = models.BooleanField(
+        default=False,
     )
 
     class Meta:

--- a/netbox_docker_plugin/tables.py
+++ b/netbox_docker_plugin/tables.py
@@ -335,8 +335,18 @@ class MountTable(NetBoxTable):
         """Mount Table definition Meta class"""
 
         model = Mount
-        fields = ("container", "source", "volume", "container")
-        default_columns = ("container", "source", "volume")
+        fields = (
+            "container",
+            "source",
+            "volume",
+            "read_only",
+        )
+        default_columns = (
+            "container",
+            "source",
+            "volume",
+            "read_only",
+        )
 
 
 class BindTable(NetBoxTable):
@@ -350,8 +360,18 @@ class BindTable(NetBoxTable):
         """Bind Table definition Meta class"""
 
         model = Bind
-        fields = ("container", "host_path", "container_path")
-        default_columns = ("container", "host_path", "container_path")
+        fields = (
+            "container",
+            "host_path",
+            "container_path",
+            "read_only",
+        )
+        default_columns = (
+            "container",
+            "host_path",
+            "container_path",
+            "read_only",
+        )
 
 
 class NetworkSettingTable(NetBoxTable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "1.6.2"
+version = "1.7.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
 ]


### PR DESCRIPTION
## Decision Record

Whether it is a Docker volume or a bind of a host path, mounts within a Docker container can be either "read only" or "read write".

Using "read only" allow the user to mount the same Docker volume or bind in multiple Docker containers.

Up until now, we were always mounting with "read write" permissions, therefore, for backward compatibility, the new field `read_only` shall be `False` by default.

## Changes

 - [x] :card_file_box: Add `read_only` field to `Mount` and `Bind` models
 - [x] :sparkles:  Add `read_only` field to corresponding serializers
 - [x] :lipstick: Add `read_only` column in corresponding tables
 - [x] :bookmark: Bump to `v1.7.0`