### PR TITLE
:bug: Do not remove container's nested resources if not explicitly set during an update

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -10,7 +10,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "1.8.0"
+    version = "1.8.1"
     base_url = "docker"
     author= "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"
     author_email= "vincent@saashup.com, david.jose.delassus@gmail.com"

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -480,37 +480,37 @@ class ContainerSerializer(NetBoxModelSerializer):
 
         container = super().update(instance, validated_data)
 
-        Port.objects.filter(container=container).delete()
         if ports_data is not None:
+            Port.objects.filter(container=container).delete()
             for port in ports_data:
                 Port.objects.create(container=container, **port)
 
-        Env.objects.filter(container=container).delete()
         if env_data is not None:
+            Env.objects.filter(container=container).delete()
             for env in env_data:
                 Env.objects.create(container=container, **env)
 
-        Label.objects.filter(container=container).delete()
         if labels_data is not None:
+            Label.objects.filter(container=container).delete()
             for label in labels_data:
                 Label.objects.create(container=container, **label)
 
-        Mount.objects.filter(container=container).delete()
         if mounts_data is not None:
+            Mount.objects.filter(container=container).delete()
             for mount in mounts_data:
                 obj = Mount(container=container, **mount)
                 obj.full_clean()
                 obj.save()
 
-        Bind.objects.filter(container=container).delete()
         if binds_data is not None:
+            Bind.objects.filter(container=container).delete()
             for bind in binds_data:
                 obj = Bind(container=container, **bind)
                 obj.full_clean()
                 obj.save()
 
-        NetworkSetting.objects.filter(container=container).delete()
         if network_settings_data is not None:
+            NetworkSetting.objects.filter(container=container).delete()
             for network_setting in network_settings_data:
                 obj = NetworkSetting(container=container, **network_setting)
                 obj.full_clean()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "1.8.0"
+version = "1.8.1"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Decision Record

Closes #124

If we don't specify for example `binds` in the body of the PATCH request, nothing will be done. However, any set value will overwrite the existing data. `binds=[]` will therefore erase any previously set value and not create new ones (it is explicitly an empty list).

## Changes

 - [x] :bug: Do not remove container's nested resources if not explicitly set during an update
 - [x] :bookmark: v1.8.1