### PR TITLE
:sparkles: Container exec

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -10,7 +10,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "1.10.0"
+    version = "1.11.0"
     base_url = "docker"
     author= "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"
     author_email= "vincent@saashup.com, david.jose.delassus@gmail.com"

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -584,3 +584,14 @@ class HostSerializer(NetBoxModelSerializer):
             "containers",
             "registries",
         )
+
+class ContainerCommandSerializer(serializers.Serializer):
+    """Container command Serializer class"""
+
+    cmd=serializers.ListField(child=serializers.CharField())
+
+    def create(self, validated_data):
+        pass
+
+    def update(self, instance, validated_data):
+        pass

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/container-exec.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/container-exec.html
@@ -1,0 +1,76 @@
+{% extends "netbox_docker_plugin/container-layout.html" %}
+
+{% load plugins %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-12">
+    <div class="card">
+      <h5 class="card-header">EXEC</h5>
+      <div class="card-body">
+        <p class="input-group">
+          <label class="input-group-text" for="container-exec-command">Command</label>
+          <input type="text" class="form-control" id="container-exec-command" data-id="{{ object.pk }}">
+          <button class="btn btn-primary" id="container-exec-button"><i class="mdi mdi-play"></i> Exec</button>
+        </p>
+        <pre id="container-exec-output" data-follow="true" class="p-2 text-white border-dark"
+          style="height: 300px; overflow-y: auto; background-color: black; resize: vertical;">
+        </pre>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block head %}
+<script type="application/javascript">
+  document.addEventListener("DOMContentLoaded", () => {
+    const input = document.getElementById("container-exec-command");
+    const button = document.getElementById("container-exec-button");
+    const pre = document.getElementById("container-exec-output");
+
+    input.addEventListener("keypress", (event) => {
+      if (event.key == "Enter") {
+        exec(input.dataset.id, input.value.split(" "), pre);
+      }
+    });
+
+    button.addEventListener("click", () => {
+      exec(input.dataset.id, input.value.split(" "), pre);
+    });
+
+    const exec = async (id, cmd, elemOutput) => {
+      document.querySelectorAll(".alert").forEach(e => e.remove());
+
+      while (elemOutput.firstChild) {
+        elemOutput.removeChild(elemOutput.lastChild);
+      }
+
+      if (cmd.length > 0 && cmd[0].length > 0) {
+        const response = await fetch(`/api/plugins/docker/containers/${id}/exec/`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": "{{ csrf_token }}"
+          },
+          body: JSON.stringify({
+            cmd: cmd
+          })
+        });
+
+        if (response.ok) {
+          elemOutput.appendChild(document.createTextNode((await response.json()).stdout))
+
+          return;
+        }
+
+        const alert = document.createElement("div");
+        alert.classList.add("alert", "alert-danger");
+        alert.appendChild(document.createTextNode("Command exec failed!"));
+
+        elemOutput.before(alert);
+      }
+    }
+  });
+</script>
+{% endblock %}

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/container-logs.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/container-logs.html
@@ -6,26 +6,18 @@
 <div class="row mb-3">
   <div class="col col-md-12">
     <div class="card">
-      <div class="card-header">
-        <div class="d-sm-flex p-2 flex-row align-items-center">
-          <h5 class="flex-grow-1">LOGS</h5>
-          <button
-            id="container-logs-button"
-            type="button"
-            class="btn btn-primary"
-          >
+      <div class="card-header d-flex">
+        <h5 class="flex-grow-1">LOGS</h5>
+        <div>
+          <button id="container-logs-button" type="button" class="btn btn-primary btn-sm">
             <i id="container-logs-cb" class="mdi mdi-checkbox-marked"></i> Follow logs
           </button>
         </div>
+      </div>
       <div class="card-body">
-        <pre
-          id="container-logs-panel"
-          data-follow="true"
-          class="p-2 text-white border-dark"
-          style="height: 300px; overflow-y: auto; background-color: black;"
-          hx-get="/api/plugins/docker/containers/{{ object.pk }}/logs/"
-          hx-trigger="load, every 30s"
-        >
+        <pre id="container-logs-panel" data-follow="true" class="p-2 text-white border-dark"
+          style="height: 300px; overflow-y: auto; background-color: black; resize: vertical;"
+          hx-get="/api/plugins/docker/containers/{{ object.pk }}/logs/" hx-trigger="load, every 30s">
         </pre>
       </div>
     </div>
@@ -35,29 +27,29 @@
 
 {% block head %}
 <script type="application/javascript">
-htmx.onLoad(function(elt) {
-  const logPanel = document.getElementById("container-logs-panel")
-  const followButton = document.getElementById("container-logs-button")
-  const checkbox = document.getElementById("container-logs-cb")
+  htmx.onLoad(function (elt) {
+    const logPanel = document.getElementById("container-logs-panel")
+    const followButton = document.getElementById("container-logs-button")
+    const checkbox = document.getElementById("container-logs-cb")
 
-  const isFollowEnabled = () => JSON.parse(logPanel.dataset.follow) === true
-  const toggleFollow = () => {
-    logPanel.dataset.follow = !isFollowEnabled()
-    followButton.classList.toggle("btn-primary")
-    followButton.classList.toggle("btn-outline-primary")
-    checkbox.classList.toggle("mdi-checkbox-marked")
-    checkbox.classList.toggle("mdi-checkbox-blank-outline")
-  }
-
-  logPanel.addEventListener("htmx:afterSwap", function() {
-    if (isFollowEnabled()) {
-      this.scrollTop = this.scrollHeight
+    const isFollowEnabled = () => JSON.parse(logPanel.dataset.follow) === true
+    const toggleFollow = () => {
+      logPanel.dataset.follow = !isFollowEnabled()
+      followButton.classList.toggle("btn-primary")
+      followButton.classList.toggle("btn-outline-primary")
+      checkbox.classList.toggle("mdi-checkbox-marked")
+      checkbox.classList.toggle("mdi-checkbox-blank-outline")
     }
-  })
 
-  followButton.addEventListener("click", function() {
-    toggleFollow()
+    logPanel.addEventListener("htmx:afterSwap", function () {
+      if (isFollowEnabled()) {
+        this.scrollTop = this.scrollHeight
+      }
+    })
+
+    followButton.addEventListener("click", function () {
+      toggleFollow()
+    })
   })
-})
 </script>
 {% endblock %}

--- a/netbox_docker_plugin/tests/container/test_container_api_exec.py
+++ b/netbox_docker_plugin/tests/container/test_container_api_exec.py
@@ -1,0 +1,96 @@
+# pylint: disable=R0801
+"""Container Test Case"""
+
+import requests_mock
+from django.urls import reverse
+from django.contrib.contenttypes.models import ContentType
+from django.core.serializers.json import DjangoJSONEncoder
+from rest_framework import status
+from users.models import ObjectPermission
+from netbox_docker_plugin.models.container import Container
+from netbox_docker_plugin.models.host import Host
+from netbox_docker_plugin.models.image import Image
+from netbox_docker_plugin.models.registry import Registry
+from netbox_docker_plugin.tests.base import BaseAPITestCase
+
+
+class ContainerApiExecTestCase(BaseAPITestCase):
+    """Container Exec Test Case Class"""
+
+    model = Container
+
+    def setUp(self):
+        super().setUp()
+
+        host1 = Host.objects.create(endpoint="http://localhost:8080", name="host1")
+
+        registry1 = Registry.objects.create(
+            host=host1, name="registry1", serveraddress="http://localhost:8080"
+        )
+
+        image1 = Image.objects.create(host=host1, name="image1", registry=registry1)
+
+        container = Container.objects.create(
+            host=host1,
+            image=image1,
+            name="container1",
+            operation="none",
+            state="created",
+            ContainerID="1234",
+        )
+
+        # Add object-level permission
+        obj_perm = ObjectPermission(
+            name="Test permission",
+            constraints={"pk": container.pk},
+            actions=["add"],
+        )
+        obj_perm.save()
+        # pylint: disable=E1101
+        obj_perm.users.add(self.user)
+        # pylint: disable=E1101
+        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+
+        self.endpoint = reverse(
+            viewname=f"plugins-api:{self._get_view_namespace()}:container-exec",
+            kwargs={"pk": container.pk},
+        )
+
+    def test_that_exec_endpoint_works(self):
+        """Test Exec endpoint"""
+
+        with requests_mock.Mocker(json_encoder=DjangoJSONEncoder) as m:
+            m.put(
+                "http://localhost:8080/api/engine/containers/1234/exec",
+                json={"stdout": "..."},
+            )
+
+            response = self.client.post(
+                self.endpoint, **self.header, data={"cmd": ["ls"]}, format="json"
+            )
+            self.assertHttpStatus(response, status.HTTP_200_OK)
+            self.assertEqual(response.data, {"stdout": "..."})
+
+    def test_that_exec_endpoint_with_invalid_command_fail(self):
+        """Test exec endpoinr with invalid command"""
+
+        response = self.client.post(
+            self.endpoint, **self.header, data={"command": ["ls"]}, format="json"
+        )
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_that_exec_endpoint_fail_with_backend_error(self):
+        """Test Exec endpoint"""
+
+        with requests_mock.Mocker(json_encoder=DjangoJSONEncoder) as m:
+            m.put(
+                "http://localhost:8080/api/engine/containers/1234/exec",
+                text="Error",
+                status_code= 500
+            )
+
+            response = self.client.post(
+                self.endpoint, **self.header, data={"cmd": ["ls"]}, format="json"
+            )
+            self.assertHttpStatus(response, status.HTTP_502_BAD_GATEWAY)
+            self.assertEqual(response.data, 'Error')

--- a/netbox_docker_plugin/urls.py
+++ b/netbox_docker_plugin/urls.py
@@ -202,6 +202,11 @@ urlpatterns = (
         name="container_logs",
     ),
     path(
+        "containers/<int:pk>/exec",
+        container_views.ContainerExecView.as_view(),
+        name="container_exec",
+    ),
+    path(
         "containers/<int:pk>/edit/",
         container_views.ContainerEditView.as_view(),
         name="container_edit",

--- a/netbox_docker_plugin/views/container.py
+++ b/netbox_docker_plugin/views/container.py
@@ -34,11 +34,20 @@ class ContainerView(generic.ObjectView):
 
 @register_model_view(Container, name="logs", path="logs")
 class ContainerLogsView(generic.ObjectView):
-    """ Logs tab in Container view """
+    """Logs tab in Container view"""
 
     queryset = Container.objects.all()
     tab = ViewTab(label="Logs")
     template_name = "netbox_docker_plugin/container-logs.html"
+
+
+@register_model_view(Container, name="exec", path="exec")
+class ContainerExecView(generic.ObjectView):
+    """Exec tab in Container view"""
+
+    queryset = Container.objects.all()
+    tab = ViewTab(label="Exec")
+    template_name = "netbox_docker_plugin/container-exec.html"
 
 
 class ContainerNewView(generic.ObjectEditView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "1.10.0"
+version = "1.11.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Decision Record

Since container exec command exists on Agent this feature is missing on Netbox.

From a container page, we need to access to a page that allow to exec a command and watch the result of the command.

![image](https://github.com/SaaShup/netbox-docker-plugin/assets/1986015/d113f445-8d86-48ee-b62d-b33393a7f518) 

## Changes

 - [x] Add new container Exec endpoint
 - [x] Add new UI for Exec command
 - [x] Update Logs page style 