### PR TITLE
:lock: Escape logs

### DIFF
--- a/netbox_docker_plugin/api/renderers.py
+++ b/netbox_docker_plugin/api/renderers.py
@@ -4,11 +4,14 @@ from django.utils.encoding import smart_str
 from rest_framework import renderers
 
 
-class PlainTextRenderer(renderers.BaseRenderer):
-    """ text/plain renderer """
+def make_content_type_renderer(content_type: str, api_format: str):
+    class ContentTypeRenderer(renderers.BaseRenderer):
+        """ content type renderer """
 
-    media_type = "text/plain"
-    format = "txt"
+        media_type = content_type
+        format = api_format
 
-    def render(self, data, accepted_media_type=None, renderer_context=None):
-        return smart_str(data, encoding=self.charset)
+        def render(self, data, accepted_media_type=None, renderer_context=None):
+            return smart_str(data, encoding=self.charset)
+
+    return ContentTypeRenderer

--- a/netbox_docker_plugin/api/renderers.py
+++ b/netbox_docker_plugin/api/renderers.py
@@ -5,6 +5,8 @@ from rest_framework import renderers
 
 
 def make_content_type_renderer(content_type: str, api_format: str):
+    """ Create a response renderer for the specific content type """
+
     class ContentTypeRenderer(renderers.BaseRenderer):
         """ content type renderer """
 

--- a/netbox_docker_plugin/api/views.py
+++ b/netbox_docker_plugin/api/views.py
@@ -1,9 +1,9 @@
 """API views definitions"""
 
 from collections.abc import Sequence
-from django.utils.html import escape
 import json
 import requests
+from django.utils.html import escape
 from rest_framework import status
 from rest_framework.renderers import JSONRenderer
 from rest_framework.decorators import action

--- a/netbox_docker_plugin/api/views.py
+++ b/netbox_docker_plugin/api/views.py
@@ -1,6 +1,7 @@
 """API views definitions"""
 
 from collections.abc import Sequence
+from django.utils.html import escape
 import json
 import requests
 from rest_framework import status
@@ -15,7 +16,7 @@ from drf_spectacular.utils import (
 from users.models import Token
 from netbox.api.viewsets import NetBoxModelViewSet
 from .. import filtersets
-from .renderers import PlainTextRenderer
+from .renderers import make_content_type_renderer
 from .serializers import (
     HostSerializer,
     ImageSerializer,
@@ -111,13 +112,13 @@ class ContainerViewSet(NetBoxModelViewSet):
     @extend_schema(
         operation_id="plugins_docker_container_logs",
         responses={
-            (200, "text/plain"): OpenApiResponse(
+            (200, "text/html"): OpenApiResponse(
                 response=str,
                 examples=[
                     OpenApiExample(
                         "Container's logs",
                         value="Hello World",
-                        media_type="text/plain",
+                        media_type="text/html",
                     ),
                 ],
             ),
@@ -136,7 +137,7 @@ class ContainerViewSet(NetBoxModelViewSet):
     @action(
         detail=True,
         methods=["get"],
-        renderer_classes=[PlainTextRenderer],
+        renderer_classes=[make_content_type_renderer("text/html", "txt")],
     )
     def logs(self, _request, **_kwargs):
         """Fetch container's logs"""
@@ -153,22 +154,22 @@ class ContainerViewSet(NetBoxModelViewSet):
 
         except requests.HTTPError:
             return Response(
-                resp.text,
+                escape(resp.text),
                 status=status.HTTP_502_BAD_GATEWAY,
-                content_type="text/plain",
+                content_type="text/html",
             )
 
         return Response(
-            resp.text,
+            escape(resp.text),
             status=status.HTTP_200_OK,
-            content_type="text/plain",
+            content_type="text/html",
         )
 
     @extend_schema(
         operation_id="plugins_docker_container_exec",
         request=ContainerCommandSerializer,
         responses={
-            (200, "text/plain"): OpenApiResponse(
+            (200, "application/json"): OpenApiResponse(
                 response=str,
                 examples=[
                     OpenApiExample(
@@ -178,13 +179,13 @@ class ContainerViewSet(NetBoxModelViewSet):
                     ),
                 ],
             ),
-            (502, "text/plain"): OpenApiResponse(
+            (502, "text/html"): OpenApiResponse(
                 response=str,
                 examples=[
                     OpenApiExample(
                         "Engine error",
                         value="Error as returned by Agent",
-                        media_type="text/plain",
+                        media_type="text/html",
                     ),
                 ],
             ),
@@ -215,9 +216,9 @@ class ContainerViewSet(NetBoxModelViewSet):
 
         except requests.HTTPError:
             return Response(
-                resp.text,
+                escape(resp.text),
                 status=status.HTTP_502_BAD_GATEWAY,
-                content_type="text/plain",
+                content_type="text/html",
             )
 
         return Response(data=json.loads(resp.text))

--- a/netbox_docker_plugin/tests/container/test_container_api.py
+++ b/netbox_docker_plugin/tests/container/test_container_api.py
@@ -266,12 +266,12 @@ class ContainerApiTestCase(
         with requests_mock.Mocker() as m:
             m.get(
                 f"http://localhost:8080/api/engine/containers/{container_id}/logs",
-                text="Hello World",
+                text="Hello > World",
             )
 
             response = self.client.get(endpoint, **self.header)
             self.assertHttpStatus(response, status.HTTP_200_OK)
-            self.assertEqual(response.data, "Hello World")
+            self.assertEqual(response.data, "Hello &gt; World")
 
     def test_that_container_host_cannot_be_changed(self):
         """Test that container's host cannot be changed"""


### PR DESCRIPTION
## Decision Record

HTMX evaluates Javascript present in responses, we need to escape the output of the following endpoints:

 - `/api/plugins/docker/containers/{id}/logs`
 - `/api/plugins/docker/containers/{id}/exec`

## Changes

 - [x] :lock: Use `django.utils.html.escape` to escape response bodies