### PR TITLE
:rocket: Update tags_cd.yml

### DIFF
--- a/.github/workflows/tags_cd.yml
+++ b/.github/workflows/tags_cd.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install netbox_docker_plugin Dependencies


### PR DESCRIPTION
We have the following warning during the deployement to PiPy : 
```
[upload release to PyPI](https://github.com/SaaShup/netbox-docker-plugin/actions/runs/9397378793/job/25880469650)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Upgrading actions to use node20 instead of node16.