### PR TITLE
:sparkles: Add ability to "Force pull" an image for v2

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -10,7 +10,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "2.2.0"
+    version = "2.3.0"
     base_url = "docker"
     min_version = "4.0.0"
     author= "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/image.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/image.html
@@ -2,6 +2,69 @@
 
 {% load plugins %}
 
+{% block extra_controls %}
+<button
+  class="btn btn-sm btn-success"
+  onclick="
+    (async () => {
+      this.setAttribute('disabled', 'disabled')
+      const notificationData = {}
+      try {
+        const resp = await fetch(
+          '/api/plugins/docker/images/{{ object.pk }}/force_pull/',
+          {
+            method: 'POST',
+            headers: {
+              'X-CSRFToken': window.CSRF_TOKEN,
+            },
+          },
+        )
+        const data = await resp.json()
+        console.log(data)
+        notificationData.kind = 'success'
+        notificationData.icon = ['mdi', 'mdi-check']
+        notificationData.message = 'Pulling image again'
+      }
+      catch (err) {
+        console.error(err)
+        notificationData.kind = 'danger'
+        notificationData.icon = ['mdi', 'mdi-alert']
+        notificationData.message = 'Failed to force pull image'
+      }
+      finally {
+        this.removeAttribute('disabled')
+      }
+      const notification = document.createElement('div')
+      notification.classList.add('toast', 'toast-dark', 'border-0', 'shadow-sm', 'rounded-0')
+      notification.setAttribute('role', 'alert')
+      notification.setAttribute('aria-live', 'assertive')
+      notification.setAttribute('aria-atomic', 'true')
+      notification.dataset['bsDelay'] = 10_000
+      const header = document.createElement('div')
+      header.classList.add('toast-header', `bg-${notificationData.kind}`, 'rounded-0')
+      const headerIcon = document.createElement('i')
+      headerIcon.classList.add(...notificationData.icon, 'me-2')
+      const headerTitle = document.createElement('span')
+      headerTitle.innerText = notificationData.message
+      const closeButton = document.createElement('button')
+      closeButton.classList.add('btn-close', 'me-0', 'm-auto')
+      closeButton.setAttribute('type', 'button')
+      closeButton.setAttribute('aria-label', 'Close')
+      closeButton.dataset['bsDismiss'] = 'toast'
+      header.appendChild(headerIcon)
+      header.appendChild(headerTitle)
+      header.appendChild(closeButton)
+      notification.appendChild(header)
+      document.querySelector('.toast-container').appendChild(notification)
+      const toast = new Toast(notification)
+      toast.show()
+    })()
+  "
+>
+  <i class="mdi mdi-reload"></i> Force Pull
+</button>
+{% endblock %}
+
 {% block content %}
 <div class="row mb-3">
   <div class="col col-md-6">

--- a/netbox_docker_plugin/tests/image/test_image_api.py
+++ b/netbox_docker_plugin/tests/image/test_image_api.py
@@ -2,7 +2,7 @@
 
 import requests_mock
 from django.urls import reverse
-from django.contrib.contenttypes.models import ContentType
+from core.models import ObjectType
 from rest_framework import status
 from users.models import ObjectPermission
 from utilities.testing import APIViewTestCases
@@ -92,7 +92,7 @@ class ImageApiTestCase(
         # pylint: disable=E1101
         obj_perm.users.add(self.user)
         # pylint: disable=E1101
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         with requests_mock.Mocker() as m:
             m.post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "2.2.0"
+version = "2.3.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Decision Record

See #144

This PR ports the feature to the plugin v2 (for Netbox v4)

## Changes

 - [x] :sparkles: Add API endpoint
 - [x] :lipstick: Add button in Image detail view
 - [x] :bookmark: v2.3.0