### PR TITLE
:lipstick: Reorganize Container detailed view (v1)

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -10,7 +10,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "1.13.0"
+    version = "1.14.0"
     max_version = "3.7.8"
     base_url = "docker"
     author= "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/container.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/container.html
@@ -54,6 +54,46 @@
   </div>
   <div class="col col-md-6">
     <div class="card">
+      <h5 class="card-header">LABELS</h5>
+      <div class="card-body htmx-container table-responsive"
+        hx-get="{% url 'plugins:netbox_docker_plugin:label_list' %}?container_id={{ object.pk }}"
+        hx-trigger="load"
+      ></div>
+      {% if perms.netbox_docker_plugin.add_env %}
+        <div class="card-footer text-end noprint">
+          <a href="{% url 'plugins:netbox_docker_plugin:label_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a Label
+          </a>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<h2>Runtime</h2>
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">ENVIRONMENT VARIABLES</h5>
+      <div class="card-body htmx-container table-responsive"
+        hx-get="{% url 'plugins:netbox_docker_plugin:env_list' %}?container_id={{ object.pk }}"
+        hx-trigger="load"
+      ></div>
+      {% if perms.netbox_docker_plugin.add_env %}
+        <div class="card-footer text-end noprint">
+          <a href="{% url 'plugins:netbox_docker_plugin:env_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Env Variable
+          </a>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<h2>Networking</h2>
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
       <h5 class="card-header">PORT MAPPINGS</h5>
       <div class="card-body htmx-container table-responsive"
         hx-get="{% url 'plugins:netbox_docker_plugin:port_list' %}?container_id={{ object.pk }}"
@@ -67,34 +107,8 @@
         </div>
       {% endif %}
     </div>
-    <div class="card">
-      <h5 class="card-header">MOUNTS</h5>
-      <div class="card-body htmx-container table-responsive"
-        hx-get="{% url 'plugins:netbox_docker_plugin:mount_list' %}?container_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
-      {% if perms.netbox_docker_plugin.add_env %}
-        <div class="card-footer text-end noprint">
-          <a href="{% url 'plugins:netbox_docker_plugin:mount_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> New Mount
-          </a>
-        </div>
-      {% endif %}
-    </div>
-    <div class="card">
-      <h5 class="card-header">BINDS</h5>
-      <div class="card-body htmx-container table-responsive"
-        hx-get="{% url 'plugins:netbox_docker_plugin:bind_list' %}?container_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
-      {% if perms.netbox_docker_plugin.add_env %}
-        <div class="card-footer text-end noprint">
-          <a href="{% url 'plugins:netbox_docker_plugin:bind_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> New Bind
-          </a>
-        </div>
-      {% endif %}
-    </div>
+  </div>
+  <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">NETWORK SETTINGS</h5>
       <div class="card-body htmx-container table-responsive"
@@ -109,30 +123,38 @@
         </div>
       {% endif %}
     </div>
+  </div>
+</div>
+
+<h2>Storage</h2>
+<div class="row mb-3">
+  <div class="col col-md-6">
     <div class="card">
-      <h5 class="card-header">ENV VARIABLE</h5>
+      <h5 class="card-header">MOUNTS</h5>
       <div class="card-body htmx-container table-responsive"
-        hx-get="{% url 'plugins:netbox_docker_plugin:env_list' %}?container_id={{ object.pk }}"
+        hx-get="{% url 'plugins:netbox_docker_plugin:mount_list' %}?container_id={{ object.pk }}"
         hx-trigger="load"
       ></div>
       {% if perms.netbox_docker_plugin.add_env %}
         <div class="card-footer text-end noprint">
-          <a href="{% url 'plugins:netbox_docker_plugin:env_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add an Env Variable
+          <a href="{% url 'plugins:netbox_docker_plugin:mount_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> New Mount
           </a>
         </div>
       {% endif %}
     </div>
+  </div>
+  <div class="col col-md-6">
     <div class="card">
-      <h5 class="card-header">LABELS</h5>
+      <h5 class="card-header">BINDS</h5>
       <div class="card-body htmx-container table-responsive"
-        hx-get="{% url 'plugins:netbox_docker_plugin:label_list' %}?container_id={{ object.pk }}"
+        hx-get="{% url 'plugins:netbox_docker_plugin:bind_list' %}?container_id={{ object.pk }}"
         hx-trigger="load"
       ></div>
       {% if perms.netbox_docker_plugin.add_env %}
         <div class="card-footer text-end noprint">
-          <a href="{% url 'plugins:netbox_docker_plugin:label_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
-            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a Label
+          <a href="{% url 'plugins:netbox_docker_plugin:bind_add' %}?container={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+            <i class="mdi mdi-plus-thick" aria-hidden="true"></i> New Bind
           </a>
         </div>
       {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "1.13.0"
+version = "1.14.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Decision Record

We are adding more and more features to the Container detail view, which clutters the right side of the page.

Let's move things around so it is a bit nicer to navigate.

![netbox](https://github.com/user-attachments/assets/1b753494-2728-435b-97ee-7c20dc1886f7)

## Changes

 - [x] :lipstick: Reorganize Container detailed view
 - [x] :bookmark: v1.14.0