### PR TITLE
:arrow_up: :pushpin: Make plugin compatible with Netbox v4.1

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.11"]
-        netbox-version: ["v4.0.11"]
+        netbox-version: ["v4.1.0"]
     services:
       redis:
         image: redis

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.11"]
-        netbox-version: ["v4.0.11"]
+        netbox-version: ["v4.1.0"]
     services:
       redis:
         image: redis

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Once the plugin and webhooks are installed, you can:
 
 ## Installation
 
+Below the compatibility list of the Netbox Docker PLugin and Netbox. Please chose the right version of the plugin depending of the Netbox version you use:
+
+| Netbox Version | Netbox Docker Plugin Version |
+| -------------- | ---------------------------- |
+| 3.\*           | 1.\*                         |
+| 4.0.\*         | 2.\*                         |
+| 4.1.\*         | 3.\*                         |
+
 You can follow [the official plugins installation
 instructions](https://docs.netbox.dev/en/stable/plugins/#installing-plugins).
 

--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -11,9 +11,9 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "2.9.0"
+    version = "3.0.0"
     base_url = "docker"
-    min_version = "4.0.0"
+    min_version = "4.1.0"
     author = "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"
     author_email = "vincent@saashup.com, david.jose.delassus@gmail.com"
 

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -4,7 +4,7 @@
 
 from rest_framework import serializers
 from utilities.query import dict_to_filter_params
-from users.api.nested_serializers import NestedTokenSerializer
+from users.models import Token
 from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
 from ..models.host import Host
 from ..models.image import Image
@@ -21,6 +21,15 @@ from ..models.container import (
     Device,
 )
 from ..models.registry import Registry
+
+
+class NestedTokenSerializer(WritableNestedSerializer):
+    """Nested Token Serializer class"""
+
+    class Meta:
+        """Nested Token Serializer Meta class"""
+        model = Token
+        fields = ["id", "url", "display_url", "display", "key", "write_enabled"]
 
 
 class NestedHostSerializer(WritableNestedSerializer):

--- a/netbox_docker_plugin/tests/container/test_container_operation_view.py
+++ b/netbox_docker_plugin/tests/container/test_container_operation_view.py
@@ -4,11 +4,11 @@
 from django.urls import reverse
 from django.test import override_settings
 from core.models import ObjectType
+from core.models import ObjectChange
+from core.choices import ObjectChangeActionChoices
 from utilities.testing import ModelViewTestCase
 from utilities.testing.utils import disable_warnings, post_data
 from users.models import ObjectPermission
-from extras.choices import ObjectChangeActionChoices
-from extras.models import ObjectChange
 from netbox_docker_plugin.models.host import Host
 from netbox_docker_plugin.models.container import Container
 from netbox_docker_plugin.models.image import Image

--- a/netbox_docker_plugin/tests/container/test_container_views.py
+++ b/netbox_docker_plugin/tests/container/test_container_views.py
@@ -66,7 +66,7 @@ class ContainerViewsTestCase(
             "host": host1.pk,
             "image": image1.pk,
             "restart_policy": "unless-stopped",
-            "cap_add": "NET_ADMIN",
+            "cap_add": ["NET_ADMIN"],
         }
 
         cls.csv_data = (

--- a/netbox_docker_plugin/tests/host/test_host_api.py
+++ b/netbox_docker_plugin/tests/host/test_host_api.py
@@ -1,8 +1,8 @@
 """Host API Test Case"""
 
 from core.models import ObjectType
-from extras.choices import ObjectChangeActionChoices
-from extras.models import ObjectChange
+from core.choices import ObjectChangeActionChoices
+from core.models import ObjectChange
 from users.models import ObjectPermission
 from rest_framework import status
 from utilities.testing import APIViewTestCases

--- a/netbox_docker_plugin/tests/host/test_host_views.py
+++ b/netbox_docker_plugin/tests/host/test_host_views.py
@@ -1,9 +1,9 @@
 """Host Views Test Case"""
 
 from core.models import ObjectType
+from core.choices import ObjectChangeActionChoices
+from core.models import ObjectChange
 from django.core.exceptions import ObjectDoesNotExist
-from extras.choices import ObjectChangeActionChoices
-from extras.models import ObjectChange
 from users.models import ObjectPermission
 from utilities.testing import ViewTestCases, post_data
 from netbox_docker_plugin.models.host import Host

--- a/netbox_docker_plugin/utilities/__init__.py
+++ b/netbox_docker_plugin/utilities/__init__.py
@@ -202,14 +202,27 @@ def create_webhook(app_config, **kwargs):
                     )
                     obj.save()
 
+                    event_types = []
+
+                    if webhook["type_create"]:
+                        event_types.append("object_created")
+
+                    if webhook["type_update"]:
+                        event_types.append("object_updated")
+
+                    if webhook["type_delete"]:
+                        event_types.append("object_deleted")
+
+                    if webhook["type_job_start"]:
+                        event_types.append("job_started")
+
+                    if webhook["type_job_end"]:
+                        event_types.append("job_completed")
+
                     eventrule = EventRule(
                         name=webhook["name"],
                         description="Added automatically by the Netbox Docker Plugin",
-                        type_create=webhook["type_create"],
-                        type_update=webhook["type_update"],
-                        type_delete=webhook["type_delete"],
-                        type_job_start=webhook["type_job_start"],
-                        type_job_end=webhook["type_job_end"],
+                        event_types=event_types,
                         action_object_id=obj.pk,
                         action_object_type=wh_content_type,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "2.9.0"
+version = "3.0.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }
 ]
 description = "Manage Docker with Netbox & style."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
Make Netbox Docker PLugin compatible with Netbox version 4.1.*

The minimal compatible version of Netbox is now v4.1.0. For compatibility with Netbox version 4.0.* please chose the version 2.9.0 of the plugin.