### PR TITLE
:bug: Fix "Follow logs" feature

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -11,7 +11,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "3.0.0"
+    version = "3.0.1"
     base_url = "docker"
     min_version = "4.1.0"
     author = "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/container-logs.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/container-logs.html
@@ -27,7 +27,7 @@
 
 {% block head %}
 <script type="application/javascript">
-  htmx.onLoad(function (elt) {
+  document.addEventListener("htmx:load", function (elt) {
     const logPanel = document.getElementById("container-logs-panel")
     const followButton = document.getElementById("container-logs-button")
     const checkbox = document.getElementById("container-logs-cb")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "3.0.0"
+version = "3.0.1"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
# Decision Record

We should use event listeners on `htmx:*` events, never the `window.htmx` library which might be undefined.

Closes: #160 

# Changes

 - [x] :bug: Replace `htmx.onLoad(...)` with `document.addEventListener('htmx:load', ...)`
 - [x] :bookmark: v3.0.1