### PR TITLE
:card_file_box: Add `max_size` field to Volume model

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -11,7 +11,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "3.0.1"
+    version = "3.1.0"
     base_url = "docker"
     min_version = "4.1.0"
     author = "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -95,6 +95,7 @@ class NestedVolumeSerializer(WritableNestedSerializer):
             "url",
             "display",
             "name",
+            "max_size",
             "driver",
         )
 
@@ -106,7 +107,11 @@ class NestedVolumeSerializer(WritableNestedSerializer):
             params = dict_to_filter_params(data)
             if Volume.objects.filter(**params).count() == 0:
                 host = Host.objects.get(pk=params["host"])
-                volume = Volume(host=host, name=params["name"])
+                volume = Volume(
+                    host=host,
+                    name=params["name"],
+                    max_size=params.get("max_size"),
+                )
                 volume.save()
                 return volume
 
@@ -263,6 +268,7 @@ class VolumeSerializer(NetBoxModelSerializer):
             "display",
             "host",
             "name",
+            "max_size",
             "driver",
             "custom_fields",
             "created",

--- a/netbox_docker_plugin/filtersets.py
+++ b/netbox_docker_plugin/filtersets.py
@@ -113,7 +113,7 @@ class VolumeFilterSet(NetBoxModelFilterSet):
         """Volume filterset definition meta class"""
 
         model = Volume
-        fields = ("id", "name", "driver", "mounts")
+        fields = ("id", "name", "max_size", "driver", "mounts")
 
     # pylint: disable=W0613
     def search(self, queryset, name, value):

--- a/netbox_docker_plugin/forms/volume.py
+++ b/netbox_docker_plugin/forms/volume.py
@@ -21,11 +21,13 @@ class VolumeForm(NetBoxModelForm):
         fields = (
             "host",
             "name",
+            "max_size",
             "driver",
             "tags",
         )
         labels = {
             "name": "Name",
+            "max_size": "Optional Maximum Size of Volume (in MB)",
             "host": "Host",
             "driver": "Driver",
         }
@@ -36,6 +38,7 @@ class VolumeFilterForm(NetBoxModelFilterSetForm):
 
     model = Volume
     name = forms.CharField(label="Name", max_length=256, min_length=1, required=False)
+    max_size = forms.IntegerField(label="Max Size (MB)", required=False)
     driver = forms.ChoiceField(
         label="Driver",
         choices=VolumeDriverChoices,
@@ -58,9 +61,10 @@ class VolumeImportForm(NetBoxModelImportForm):
         """Volume importation form definition Meta class"""
 
         model = Volume
-        fields = ("name", "driver", "host")
+        fields = ("name", "max_size", "driver", "host")
         labels = {
             "name": "Unique Image name",
+            "max_size": "Optional Maximum Size of Volume (in MB)",
             "driver": 'Volume provider. Can be "local"',
             "host": "Host identifier",
         }

--- a/netbox_docker_plugin/migrations/0034_volume_max_size.py
+++ b/netbox_docker_plugin/migrations/0034_volume_max_size.py
@@ -1,0 +1,20 @@
+# pylint: disable=C0103
+"""Migration file"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration file"""
+
+    dependencies = [
+        ("netbox_docker_plugin", "0033_host_operation"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="volume",
+            name="max_size",
+            field=models.PositiveIntegerField(null=True, default=None),
+        ),
+    ]

--- a/netbox_docker_plugin/migrations/0034_volume_max_size.py
+++ b/netbox_docker_plugin/migrations/0034_volume_max_size.py
@@ -15,6 +15,10 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="volume",
             name="max_size",
-            field=models.PositiveIntegerField(null=True, default=None),
+            field=models.PositiveIntegerField(
+                null=True,
+                blank=True,
+                default=None,
+            ),
         ),
     ]

--- a/netbox_docker_plugin/models/volume.py
+++ b/netbox_docker_plugin/models/volume.py
@@ -34,6 +34,10 @@ class Volume(NetBoxModel):
             MaxLengthValidator(limit_value=255),
         ],
     )
+    max_size = models.PositiveIntegerField(
+        null=True,
+        default=None,
+    )
     driver = models.CharField(
         max_length=32,
         choices=VolumeDriverChoices,

--- a/netbox_docker_plugin/models/volume.py
+++ b/netbox_docker_plugin/models/volume.py
@@ -36,6 +36,7 @@ class Volume(NetBoxModel):
     )
     max_size = models.PositiveIntegerField(
         null=True,
+        blank=True,
         default=None,
     )
     driver = models.CharField(

--- a/netbox_docker_plugin/tables.py
+++ b/netbox_docker_plugin/tables.py
@@ -170,8 +170,23 @@ class VolumeTable(NetBoxTable):
         """Volume Table definition Meta class"""
 
         model = Volume
-        fields = ("pk", "id", "host", "name", "driver", "mount_count", "tags")
-        default_columns = ("name", "driver", "host", "mount_count")
+        fields = (
+            "pk",
+            "id",
+            "host",
+            "name",
+            "max_size",
+            "driver",
+            "mount_count",
+            "tags",
+        )
+        default_columns = (
+            "name",
+            "max_size",
+            "driver",
+            "host",
+            "mount_count",
+        )
 
 
 class NetworkTable(NetBoxTable):

--- a/netbox_docker_plugin/tables.py
+++ b/netbox_docker_plugin/tables.py
@@ -166,6 +166,10 @@ class VolumeTable(NetBoxTable):
     )
     tags = columns.TagColumn()
 
+    def render_max_size(self, value):
+        """Render the volume max size with unity"""
+        return f"{value} MB"
+
     class Meta(NetBoxTable.Meta):
         """Volume Table definition Meta class"""
 

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/volume.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/volume.html
@@ -21,6 +21,16 @@
             <th scope="row">Driver</th>
             <td>{{ object.get_driver_display }}</td>
           </tr>
+          <tr>
+            <th scope="row">Max size</th>
+            <td>
+              {% if object.max_size is None %}
+                {{ object.max_size|placeholder }}
+              {% else %}
+                {{ object.max_size }}&nbsp;MByte
+              {% endif %}
+            </td>
+          </tr>
         </table>
       </div>
     </div>

--- a/netbox_docker_plugin/tests/volume/test_volume_api.py
+++ b/netbox_docker_plugin/tests/volume/test_volume_api.py
@@ -24,7 +24,7 @@ class VolumeApiTestCase(
     """Volume Test Case Class"""
 
     model = Volume
-    brief_fields = ["display", "driver", "id", "name", "url"]
+    brief_fields = ["display", "driver", "id", "max_size", "name", "url"]
 
     @classmethod
     def setUpTestData(cls) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "3.0.1"
+version = "3.1.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Decision Record

We might want to be able to specify the maximum size (in MB) of a Volume so that the container cannot fill the host's disk.

## Changes

 - [x] :card_file_box: Add `max_size` field to Volume model
 - [x] :bookmark: v3.1.0