### PR TITLE
:sparkles: More filter fields

### DIFF
--- a/netbox_docker_plugin/filtersets.py
+++ b/netbox_docker_plugin/filtersets.py
@@ -166,7 +166,14 @@ class ContainerFilterSet(NetBoxModelFilterSet):
         """Container filterset definition meta class"""
 
         model = Container
-        fields = ("id", "name", "state", "hostname", "restart_policy")
+        fields = (
+            "id",
+            "name",
+            "state",
+            "hostname",
+            "restart_policy",
+            "ContainerID",
+        )
 
     # pylint: disable=W0613
     def search(self, queryset, name, value):

--- a/netbox_docker_plugin/filtersets.py
+++ b/netbox_docker_plugin/filtersets.py
@@ -89,7 +89,15 @@ class ImageFilterSet(NetBoxModelFilterSet):
         """Image filterset definition meta class"""
 
         model = Image
-        fields = ("id", "name", "version", "size", "ImageID", "containers")
+        fields = (
+            "id",
+            "name",
+            "version",
+            "size",
+            "ImageID",
+            "Digest",
+            "containers",
+        )
 
     # pylint: disable=W0613
     def search(self, queryset, name, value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "3.1.0"
+version = "3.2.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
# Context

In this PR https://github.com/SaaShup/netbox-docker-agent/pull/185, I had to fetch a container by its `ContainerID`, but it's not one of the filterable fields.

This PR add missing fields to the `ImageFilterSet` and `ContainerFilterSet`

# Changes

 - [x] :sparkles: Add `Digest` field to `ImageFilterSet`
 - [x] :sparkles: Add `ContainerID` field to `ContainerFilterSet`
 - [x] :bookmark: v3.2.0