### PR TITLE
:tada: changing en var value from 256 to 32768

### DIFF
--- a/netbox_docker_plugin/migrations/0037_alter_env_value.py
+++ b/netbox_docker_plugin/migrations/0037_alter_env_value.py
@@ -17,10 +17,10 @@ class Migration(migrations.Migration):
             model_name="env",
             name="value",
             field=models.CharField(
+                blank=True,
                 max_length=32768,
                 validators=[
-                    django.core.validators.MinLengthValidator(limit_value=1),
-                    django.core.validators.MaxLengthValidator(limit_value=32768),
+                    django.core.validators.MaxLengthValidator(limit_value=32768)
                 ],
             ),
         ),

--- a/netbox_docker_plugin/migrations/0037_alter_env_value_size.py
+++ b/netbox_docker_plugin/migrations/0037_alter_env_value_size.py
@@ -1,0 +1,27 @@
+# pylint: disable=C0103
+"""Migration file"""
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration file"""
+
+    dependencies = [
+        ("netbox_docker_plugin", "0036_alter_container_log_driver"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="env",
+            name="value",
+            field=models.CharField(
+                max_length=32768,
+                validators=[
+                    django.core.validators.MinLengthValidator(limit_value=1),
+                    django.core.validators.MaxLengthValidator(limit_value=32768),
+                ],
+            ),
+        ),
+    ]

--- a/netbox_docker_plugin/models/container.py
+++ b/netbox_docker_plugin/models/container.py
@@ -333,9 +333,9 @@ class Env(models.Model):
     )
     value = models.CharField(
         blank=True,
-        max_length=4096,
+        max_length=32768,
         validators=[
-            MaxLengthValidator(limit_value=4096),
+            MaxLengthValidator(limit_value=32768),
         ],
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "4.0.1"
+version = "4.1.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
During the deployment of containers it could happen the environment variables are quite large.

For the moment we allow 4096 characters. Docker does not have a real value for this.

Changing this value from 4096 to 32768.