### PR TITLE
Add Token Description on Add Host

### DIFF
--- a/netbox_docker_plugin/api/views.py
+++ b/netbox_docker_plugin/api/views.py
@@ -47,13 +47,13 @@ class HostViewSet(NetBoxModelViewSet):
     def perform_create(self, serializer):
         if isinstance(serializer.validated_data, Sequence):
             for obj in serializer.validated_data:
-                token = Token(user=self.request.user, write_enabled=True)
+                token = Token(user=self.request.user, write_enabled=True, description="Docker Agent")
                 token.save()
 
                 obj["token"] = token
                 obj["netbox_base_url"] = self.request.stream.META["HTTP_ORIGIN"]
         else:
-            token = Token(user=self.request.user, write_enabled=True)
+            token = Token(user=self.request.user, write_enabled=True, description="Docker Agent")
             token.save()
 
             serializer.validated_data["token"] = token

--- a/netbox_docker_plugin/api/views.py
+++ b/netbox_docker_plugin/api/views.py
@@ -47,13 +47,13 @@ class HostViewSet(NetBoxModelViewSet):
     def perform_create(self, serializer):
         if isinstance(serializer.validated_data, Sequence):
             for obj in serializer.validated_data:
-                token = Token(user=self.request.user, write_enabled=True, description="Docker Agent")
+                token = Token(user=self.request.user, write_enabled=True, description="DockerAgent")
                 token.save()
 
                 obj["token"] = token
                 obj["netbox_base_url"] = self.request.stream.META["HTTP_ORIGIN"]
         else:
-            token = Token(user=self.request.user, write_enabled=True, description="Docker Agent")
+            token = Token(user=self.request.user, write_enabled=True, description="DockerAgent")
             token.save()
 
             serializer.validated_data["token"] = token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "4.6.0"
+version = "4.7.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
When we add a docker host we create a Token for further update from the agent to netbox.

The token has no description for the moment.

I propose as first step to add a simple description so we know it has been created for Docker Agent management purpose.  