### PR TITLE
fix: increase Docker registry username max_length to 2048 chars

### DIFF
--- a/netbox_docker_plugin/migrations/1042_registry_username_max_length.py
+++ b/netbox_docker_plugin/migrations/1042_registry_username_max_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_docker_plugin", "1041_sysctl"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="registry",
+            name="username",
+            field=models.CharField(blank=True, max_length=2048, null=True),
+        ),
+    ]

--- a/netbox_docker_plugin/models/registry.py
+++ b/netbox_docker_plugin/models/registry.py
@@ -37,7 +37,7 @@ class Registry(NetBoxModel):
         ],
     )
     serveraddress = models.URLField()
-    username = models.CharField(blank=True, null=True, max_length=512)
+    username = models.CharField(blank=True, null=True, max_length=2048)
     password = models.CharField(blank=True, null=True, max_length=512)
     email = models.EmailField(blank=True, null=True, max_length=512)
 


### PR DESCRIPTION
## Summary

Increases the `username` field on the `Registry` model from 512 to 2048 characters.

Enterprise environments commonly use long identity strings such as OAuth tokens, SSO identifiers, and encoded service account credentials that exceed the previous limit.

## Changes
- `netbox_docker_plugin/models/registry.py`: updated `max_length=512` → `max_length=2048`
- Added Django migration `1042_registry_username_max_length.py`

Closes #224