### PR TITLE
:wrench: Declare dev dependencies in pyproject.toml

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -51,8 +51,7 @@ jobs:
       - name: Install netbox_docker_plugin Dependencies
         working-directory: netbox-docker-plugin
         run: |
-          pip install .
-          pip install requests_mock
+          pip install -e ".[dev]"
       - name: Install netbox Dependencies
         working-directory: netbox
         run: |
@@ -61,12 +60,10 @@ jobs:
           pip install -r requirements.txt -U
       - name: Run Pylint
         run: |
-          pip install pylint
           pylint --rcfile $(pwd)/netbox-docker-plugin/.pylintrc --init-hook 'import os; import sys; sys.path.append(os.getcwd() + "/netbox/netbox")' $(pwd)/netbox-docker-plugin/netbox_docker_plugin/
       - name: Run tests with coverage and edit coverage report
         working-directory: netbox
         run: |
-          python3 -m pip install coverage
           coverage run --include='*/netbox_docker_plugin/*' netbox/manage.py test netbox_docker_plugin.tests -v 2
           coverage report -m
           coverage xml -o coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 keywords = ["netbox", "netbox-plugin", "docker"]
+[project.optional-dependencies]
+dev = [
+    "requests-mock",
+    "coverage",
+    "pylint",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/SaaShup/netbox-docker-plugin"


### PR DESCRIPTION
Group requests-mock, coverage and pylint under [project.optional-dependencies] dev so the project can be set up with a single `pip install -e ".[dev]"`. Update pr_ci.yml to use this instead of ad-hoc pip installs.