### PR TITLE
:sparkles: Link Host to VirtualMachine + validate Container image ID

### DIFF
--- a/netbox_docker_plugin/__init__.py
+++ b/netbox_docker_plugin/__init__.py
@@ -11,7 +11,7 @@ class NetBoxDockerConfig(PluginConfig):
     name = "netbox_docker_plugin"
     verbose_name = " NetBox Docker Plugin"
     description = "Manage Docker"
-    version = "5.1.1"
+    version = "5.2.0"
     base_url = "docker"
     min_version = "4.5.0"
     author = "Vincent Simonin <vincent@saashup.com>, David Delassus <david.jose.delassus@gmail.com>"

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from utilities.query import dict_to_filter_params
 from users.models import Token
 from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
+from virtualization.api.serializers import VirtualMachineSerializer
 from ..models.host import Host
 from ..models.image import Image
 from ..models.volume import Volume
@@ -693,6 +694,7 @@ class HostSerializer(NetBoxModelSerializer):
     containers = NestedContainerSerializer(many=True, read_only=True)
     registries = NestedRegistrySerializer(many=True, read_only=True)
     token = NestedTokenSerializer(read_only=True)
+    virtual_machine = VirtualMachineSerializer(required=False)
 
     class Meta:
         """Host Serializer Meta class"""
@@ -706,6 +708,7 @@ class HostSerializer(NetBoxModelSerializer):
             "name",
             "state",
             "token",
+            "virtual_machine",
             "netbox_base_url",
             "agent_version",
             "docker_api_version",

--- a/netbox_docker_plugin/api/serializers.py
+++ b/netbox_docker_plugin/api/serializers.py
@@ -5,8 +5,8 @@
 from rest_framework import serializers
 from utilities.query import dict_to_filter_params
 from users.models import Token
-from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
 from virtualization.api.serializers import VirtualMachineSerializer
+from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
 from ..models.host import Host
 from ..models.image import Image
 from ..models.volume import Volume

--- a/netbox_docker_plugin/api/views.py
+++ b/netbox_docker_plugin/api/views.py
@@ -39,7 +39,13 @@ class HostViewSet(NetBoxModelViewSet):
     """Host view set class"""
 
     queryset = Host.objects.prefetch_related(
-        "images", "volumes", "networks", "containers", "registries", "tags"
+        "images",
+        "volumes",
+        "networks",
+        "containers",
+        "registries",
+        "virtual_machine",
+        "tags",
     )
     filterset_class = filtersets.HostFilterSet
     serializer_class = HostSerializer
@@ -108,7 +114,7 @@ class ImageViewSet(NetBoxModelViewSet):
                 url,
                 timeout=10,
                 data=json.dumps({"data": data}, cls=DjangoJSONEncoder),
-                headers={"Content-Type": "application/json"}
+                headers={"Content-Type": "application/json"},
             )
             resp.raise_for_status()
 

--- a/netbox_docker_plugin/filtersets.py
+++ b/netbox_docker_plugin/filtersets.py
@@ -38,6 +38,7 @@ class HostFilterSet(NetBoxModelFilterSet):
             "state",
             "agent_version",
             "docker_api_version",
+            "virtual_machine",
         )
 
     # pylint: disable=W0613

--- a/netbox_docker_plugin/forms/host.py
+++ b/netbox_docker_plugin/forms/host.py
@@ -2,18 +2,26 @@
 
 from django import forms
 from utilities.forms.rendering import FieldSet
-from utilities.forms.fields import TagFilterField
+from utilities.forms.fields import TagFilterField, DynamicModelChoiceField
 from netbox.forms import (
     NetBoxModelForm,
     NetBoxModelImportForm,
     NetBoxModelFilterSetForm,
     NetBoxModelBulkEditForm,
 )
+from virtualization.models import VirtualMachine
 from ..models.host import Host, HostStateChoices
 
 
-class HostForm(NetBoxModelForm):
+class HostAddForm(NetBoxModelForm):
     """Host form definition class"""
+
+    virtual_machine = DynamicModelChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        selector=True,
+        required=False,
+        label="Virtual Machine",
+    )
 
     class Meta:
         """Host form definition Meta class"""
@@ -22,6 +30,34 @@ class HostForm(NetBoxModelForm):
         fields = (
             "name",
             "endpoint",
+            "virtual_machine",
+        )
+        help_texts = {"name": "Unique Name", "endpoint": "Docker instance endpoint"}
+        labels = {"name": "Name", "endpoint": "Endpoint"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields.pop("tags", None)
+
+
+class HostForm(NetBoxModelForm):
+    """Host form definition class"""
+
+    virtual_machine = DynamicModelChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        selector=True,
+        required=False,
+        label="Virtual Machine",
+    )
+
+    class Meta:
+        """Host form definition Meta class"""
+
+        model = Host
+        fields = (
+            "name",
+            "endpoint",
+            "virtual_machine",
             "tags",
         )
         help_texts = {"name": "Unique Name", "endpoint": "Docker instance endpoint"}

--- a/netbox_docker_plugin/forms/host.py
+++ b/netbox_docker_plugin/forms/host.py
@@ -3,13 +3,13 @@
 from django import forms
 from utilities.forms.rendering import FieldSet
 from utilities.forms.fields import TagFilterField, DynamicModelChoiceField
+from virtualization.models import VirtualMachine
 from netbox.forms import (
     NetBoxModelForm,
     NetBoxModelImportForm,
     NetBoxModelFilterSetForm,
     NetBoxModelBulkEditForm,
 )
-from virtualization.models import VirtualMachine
 from ..models.host import Host, HostStateChoices
 
 

--- a/netbox_docker_plugin/migrations/1044_host_virtual_machine.py
+++ b/netbox_docker_plugin/migrations/1044_host_virtual_machine.py
@@ -13,7 +13,6 @@ class Migration(migrations.Migration):
             "netbox_docker_plugin",
             "1043_container_cap_drop_container_extra_hosts_and_more",
         ),
-        ("virtualization", "0056_virtualmachine_render_config_permission"),
     ]
 
     operations = [

--- a/netbox_docker_plugin/migrations/1044_host_virtual_machine.py
+++ b/netbox_docker_plugin/migrations/1044_host_virtual_machine.py
@@ -1,0 +1,30 @@
+# pylint: disable=C0103
+"""Migration file"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration file"""
+
+    dependencies = [
+        (
+            "netbox_docker_plugin",
+            "1043_container_cap_drop_container_extra_hosts_and_more",
+        ),
+        ("virtualization", "0056_virtualmachine_render_config_permission"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="host",
+            name="virtual_machine",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to="virtualization.virtualmachine",
+            ),
+        ),
+    ]

--- a/netbox_docker_plugin/models/container.py
+++ b/netbox_docker_plugin/models/container.py
@@ -328,11 +328,17 @@ class Container(NetBoxModel):
         return reverse("plugins:netbox_docker_plugin:container", args=[self.pk])
 
     def clean(self):
+        """Validate that the image belongs to the same host and has been pulled."""
         super().clean()
 
         if self.host != self.image.host:
             raise ValidationError(
                 {"image": f"Image {self.image} does not belong to host {self.host}."}
+            )
+
+        if not self.image.ImageID:
+            raise ValidationError(
+                {"image": f"Image {self.image} has no ID yet. Pull or refresh it first."}
             )
 
 

--- a/netbox_docker_plugin/models/host.py
+++ b/netbox_docker_plugin/models/host.py
@@ -9,8 +9,8 @@ from django.core.validators import (
 )
 from utilities.choices import ChoiceSet
 from users.models import Token
-from netbox.models import NetBoxModel
 from virtualization.models import VirtualMachine
+from netbox.models import NetBoxModel
 
 
 class HostStateChoices(ChoiceSet):

--- a/netbox_docker_plugin/models/host.py
+++ b/netbox_docker_plugin/models/host.py
@@ -10,6 +10,7 @@ from django.core.validators import (
 from utilities.choices import ChoiceSet
 from users.models import Token
 from netbox.models import NetBoxModel
+from virtualization.models import VirtualMachine
 
 
 class HostStateChoices(ChoiceSet):
@@ -64,6 +65,12 @@ class Host(NetBoxModel):
         default=HostStateChoices.STATE_CREATED,
     )
     token = models.ForeignKey(Token, on_delete=models.SET_NULL, null=True, blank=True)
+    virtual_machine = models.OneToOneField(
+        VirtualMachine,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
     netbox_base_url = models.CharField(
         max_length=1024,
         validators=[URLValidator()],

--- a/netbox_docker_plugin/tables.py
+++ b/netbox_docker_plugin/tables.py
@@ -26,6 +26,7 @@ class HostTable(NetBoxTable):
     """Host Table definition class"""
 
     name = tables.Column(linkify=True)
+    virtual_machine = tables.Column(linkify=True, verbose_name="Virtual Machine")
     image_count = columns.LinkedCountColumn(
         viewname="plugins:netbox_docker_plugin:image_list",
         url_params={"host_id": "pk"},
@@ -62,6 +63,7 @@ class HostTable(NetBoxTable):
             "name",
             "endpoint",
             "state",
+            "virtual_machine",
             "agent_version",
             "docker_api_version",
             "image_count",

--- a/netbox_docker_plugin/template_content.py
+++ b/netbox_docker_plugin/template_content.py
@@ -1,0 +1,23 @@
+"""Template modifications definitions"""
+
+# pylint: disable=W0223
+
+from netbox.plugins import PluginTemplateExtension
+from .models import Host
+
+
+class VirtualMachineHostTable(PluginTemplateExtension):
+    """Virtual machine object template"""
+
+    models = ["virtualization.virtualmachine"]
+
+    def right_page(self):
+        return self.render(
+            "netbox_docker_plugin/virtual_machine_host_table.html",
+            extra_context={
+                "Host": Host.objects.filter(virtual_machine=self.context["object"])
+            },
+        )
+
+
+template_extensions = [VirtualMachineHostTable]

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/host.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/host.html
@@ -28,6 +28,17 @@
           <td>{{ object.endpoint|remove_password }}</td>
         </tr>
         <tr>
+          <th scope="row">Virtual Machine</th>
+          <td>
+            {% if object.virtual_machine %}
+            <a href="{% url 'virtualization:virtualmachine' pk=object.virtual_machine.pk %}">
+              {{ object.virtual_machine|placeholder }}</a>
+            {% else %}
+            {{ object.virtual_machine|placeholder }}</a>
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
           <th scope="row">State</th>
           <td>{{ object.get_state_display }}</td>
         </tr>

--- a/netbox_docker_plugin/templates/netbox_docker_plugin/virtual_machine_host_table.html
+++ b/netbox_docker_plugin/templates/netbox_docker_plugin/virtual_machine_host_table.html
@@ -1,0 +1,4 @@
+<div class="card">
+    <h2 class="card-header">Docker Host</h2>
+    {% htmx_table 'plugins:netbox_docker_plugin:host_list' virtual_machine=object.pk %}
+</div>

--- a/netbox_docker_plugin/tests/container/test_container_api.py
+++ b/netbox_docker_plugin/tests/container/test_container_api.py
@@ -70,8 +70,18 @@ class ContainerApiTestCase(
             host=host2, name="registry2", serveraddress="http://localhost:8082"
         )
 
-        image1 = Image.objects.create(host=host1, name="image1", registry=registry1)
-        image2 = Image.objects.create(host=host2, name="image2", registry=registry2)
+        image1 = Image.objects.create(
+            host=host1,
+            name="image1",
+            registry=registry1,
+            ImageID="sha256:abc123",
+        )
+        image2 = Image.objects.create(
+            host=host2,
+            name="image2",
+            registry=registry2,
+            ImageID="sha256:abc456",
+        )
 
         network1 = Network.objects.create(host=host1, name="network1")
         network2 = Network.objects.create(host=host2, name="network2")
@@ -244,6 +254,7 @@ class ContainerApiTestCase(
             host=host3,
             name="image3",
             registry=registry3,
+            ImageID="sha256:abc789",
         )
         container11 = Container.objects.create(
             host=host3,
@@ -330,8 +341,18 @@ class ContainerApiTestCase(
             host=host2, name="registry5", serveraddress="http://localhost:8082"
         )
 
-        image1 = Image.objects.create(host=host1, name="image", registry=registry1)
-        image2 = Image.objects.create(host=host2, name="image", registry=registry2)
+        image1 = Image.objects.create(
+            host=host1,
+            name="image",
+            registry=registry1,
+            ImageID="sha256:abc101112",
+        )
+        image2 = Image.objects.create(
+            host=host2,
+            name="image",
+            registry=registry2,
+            ImageID="sha256:abc131415",
+        )
 
         container = Container.objects.create(host=host1, image=image1, name="container")
 

--- a/netbox_docker_plugin/tests/container/test_container_api_exec.py
+++ b/netbox_docker_plugin/tests/container/test_container_api_exec.py
@@ -28,7 +28,12 @@ class ContainerApiExecTestCase(BaseAPITestCase):
             host=host1, name="registry1", serveraddress="http://localhost:8080"
         )
 
-        image1 = Image.objects.create(host=host1, name="image1", registry=registry1)
+        image1 = Image.objects.create(
+            host=host1,
+            name="image1",
+            registry=registry1,
+            ImageID="sha256:abc123",
+        )
 
         container = Container.objects.create(
             host=host1,
@@ -86,11 +91,11 @@ class ContainerApiExecTestCase(BaseAPITestCase):
             m.put(
                 "http://localhost:8080/api/engine/containers/1234/exec",
                 text="Error",
-                status_code= 500
+                status_code=500,
             )
 
             response = self.client.post(
                 self.endpoint, **self.header, data={"cmd": ["ls"]}, format="json"
             )
             self.assertHttpStatus(response, status.HTTP_502_BAD_GATEWAY)
-            self.assertEqual(response.data, 'Error')
+            self.assertEqual(response.data, "Error")

--- a/netbox_docker_plugin/tests/container/test_container_operation_view.py
+++ b/netbox_docker_plugin/tests/container/test_container_operation_view.py
@@ -257,8 +257,12 @@ class ContainerViewsTestCase(BaseModelViewTestCase, ModelViewTestCase):
             host=host2, name="registry2", serveraddress="http://localhost:8082"
         )
 
-        image1 = Image.objects.create(host=host1, name="image1", registry=registry1)
-        image2 = Image.objects.create(host=host2, name="image2", registry=registry2)
+        image1 = Image.objects.create(
+            host=host1, name="image1", registry=registry1, ImageID="sha256:abc123"
+        )
+        image2 = Image.objects.create(
+            host=host2, name="image2", registry=registry2, ImageID="sha256:abc456"
+        )
 
         Container.objects.create(
             host=host1,

--- a/netbox_docker_plugin/tests/container/test_container_validation.py
+++ b/netbox_docker_plugin/tests/container/test_container_validation.py
@@ -39,6 +39,36 @@ class ContainerValidationTestCase(TestCase):
 
         self.assertTrue(isinstance(container.id, int))
 
+    def test_that_container_image_must_have_an_id(self):
+        """Test that the image must have been pulled (non-empty ImageID)"""
+
+        with self.assertRaises(ValidationError) as cm:
+            container = Container(
+                host=self.objects["host1"],
+                image=self.objects["image1"],
+                name="container_no_image_id",
+                operation="none",
+                state="created",
+            )
+            container.clean()
+
+        self.assertEqual(
+            cm.exception.message_dict["image"],
+            ["Image image1:latest has no ID yet. Pull or refresh it first."],
+        )
+
+    def test_that_container_image_with_id_passes_validation(self):
+        """Test that an image with a non-empty ImageID passes validation"""
+
+        container = Container(
+            host=self.objects["host1"],
+            image=self.objects["image1_pulled"],
+            name="container_with_image_id",
+            operation="none",
+            state="created",
+        )
+        container.clean()  # must not raise
+
     def test_that_container_image_must_be_on_the_same_host(self):
         """Test that Container image must be on the same host"""
 
@@ -137,6 +167,12 @@ class ContainerValidationTestCase(TestCase):
 
         cls.objects["image1"] = Image.objects.create(
             host=cls.objects["host1"], name="image1", registry=cls.objects["registry1"]
+        )
+        cls.objects["image1_pulled"] = Image.objects.create(
+            host=cls.objects["host1"],
+            name="image1_pulled",
+            registry=cls.objects["registry1"],
+            ImageID="sha256:abc123",
         )
         cls.objects["image2"] = Image.objects.create(
             host=cls.objects["host2"], name="image2", registry=cls.objects["registry2"]

--- a/netbox_docker_plugin/tests/container/test_container_views.py
+++ b/netbox_docker_plugin/tests/container/test_container_views.py
@@ -28,8 +28,12 @@ class ContainerViewsTestCase(
             host=host2, name="registry2", serveraddress="http://localhost:8082"
         )
 
-        image1 = Image.objects.create(host=host1, name="image1", registry=registry1)
-        image2 = Image.objects.create(host=host2, name="image2", registry=registry2)
+        image1 = Image.objects.create(
+            host=host1, name="image1", registry=registry1, ImageID="sha256:abc123"
+        )
+        image2 = Image.objects.create(
+            host=host2, name="image2", registry=registry2, ImageID="sha256:abc456"
+        )
 
         container1 = Container.objects.create(
             host=host1,

--- a/netbox_docker_plugin/tests/host/test_host_views.py
+++ b/netbox_docker_plugin/tests/host/test_host_views.py
@@ -26,6 +26,7 @@ class HostViewsTestCase(BaseModelViewTestCase, ViewTestCases.PrimaryObjectViewTe
         "host7,http://localhost:8084",
     )
     bulk_edit_data = {"endpoint": "http://localhost:8083"}
+    validation_excluded_fields = ["tags"]
 
     def setUp(self):
         super().setUp()
@@ -91,8 +92,7 @@ class HostViewsTestCase(BaseModelViewTestCase, ViewTestCases.PrimaryObjectViewTe
         """Test the host error state"""
 
         self.assertEqual(
-           self.objects["host_error_state"].state,
-            HostStateChoices.STATE_ERROR
+            self.objects["host_error_state"].state, HostStateChoices.STATE_ERROR
         )
 
     @classmethod

--- a/netbox_docker_plugin/tests/host/test_host_virtual_machine.py
+++ b/netbox_docker_plugin/tests/host/test_host_virtual_machine.py
@@ -1,0 +1,74 @@
+"""Host ↔ VirtualMachine relationship tests"""
+
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from virtualization.models import VirtualMachine
+
+from netbox_docker_plugin.models.host import Host
+
+
+class HostVirtualMachineTestCase(TestCase):
+    """Test the optional OneToOne link between Host and VirtualMachine."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.vm1 = VirtualMachine.objects.create(name="vm1")
+        cls.vm2 = VirtualMachine.objects.create(name="vm2")
+        cls.host = Host.objects.create(
+            endpoint="http://localhost:8080",
+            name="host1",
+        )
+
+    def test_host_without_virtual_machine(self):
+        """A Host with no VirtualMachine linked is valid."""
+        host = Host.objects.create(endpoint="http://localhost:8081", name="host2")
+        self.assertIsNone(host.virtual_machine)
+
+    def test_host_with_virtual_machine(self):
+        """A Host can be linked to a VirtualMachine."""
+        self.host.virtual_machine = self.vm1
+        self.host.save()
+        self.host.refresh_from_db()
+        self.assertEqual(self.host.virtual_machine, self.vm1)
+
+    def test_one_to_one_constraint(self):
+        """Two Hosts cannot share the same VirtualMachine."""
+        Host.objects.create(
+            endpoint="http://localhost:8082",
+            name="host_a",
+            virtual_machine=self.vm2,
+        )
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                Host.objects.create(
+                    endpoint="http://localhost:8083",
+                    name="host_b",
+                    virtual_machine=self.vm2,
+                )
+
+    def test_virtual_machine_set_null_on_delete(self):
+        """Deleting the VirtualMachine sets the Host FK to NULL (SET_NULL)."""
+        vm = VirtualMachine.objects.create(name="vm_to_delete")
+        host = Host.objects.create(
+            endpoint="http://localhost:8084",
+            name="host_set_null",
+            virtual_machine=vm,
+        )
+        vm.delete()
+        host.refresh_from_db()
+        self.assertIsNone(host.virtual_machine)
+
+    def test_unlink_virtual_machine(self):
+        """Setting virtual_machine to None removes the link without deleting either object."""
+        vm = VirtualMachine.objects.create(name="vm_unlink")
+        host = Host.objects.create(
+            endpoint="http://localhost:8085",
+            name="host_unlink",
+            virtual_machine=vm,
+        )
+        host.virtual_machine = None
+        host.save()
+        host.refresh_from_db()
+        self.assertIsNone(host.virtual_machine)
+        self.assertTrue(VirtualMachine.objects.filter(pk=vm.pk).exists())

--- a/netbox_docker_plugin/tests/volume/test_volume_api.py
+++ b/netbox_docker_plugin/tests/volume/test_volume_api.py
@@ -72,7 +72,9 @@ class VolumeApiTestCase(
             host=host, name="registry8", serveraddress="http://localhost:8089"
         )
 
-        image = Image.objects.create(host=host, name="image8", registry=registry)
+        image = Image.objects.create(
+            host=host, name="image8", registry=registry, ImageID="sha256:abc123"
+        )
 
         container = Container.objects.create(host=host, image=image, name="container8")
 

--- a/netbox_docker_plugin/urls.py
+++ b/netbox_docker_plugin/urls.py
@@ -29,7 +29,7 @@ from .views import (
 urlpatterns = (
     # Host
     path("hosts/", host_views.HostListView.as_view(), name="host_list"),
-    path("hosts/add/", host_views.HostEditView.as_view(), name="host_add"),
+    path("hosts/add/", host_views.HostAddView.as_view(), name="host_add"),
     path(
         "hosts/import/",
         host_views.HostBulkImportView.as_view(),

--- a/netbox_docker_plugin/views/host.py
+++ b/netbox_docker_plugin/views/host.py
@@ -19,7 +19,7 @@ class HostView(GetRelatedModelsMixin, generic.ObjectView):
     """Host view definition"""
 
     queryset = Host.objects.prefetch_related(
-        "images", "volumes", "networks", "containers", "registries"
+        "images", "volumes", "networks", "containers", "registries", "virtual_machine"
     )
 
     def get_extra_context(self, request, instance):
@@ -57,21 +57,30 @@ class HostListView(generic.ObjectListView):
     filterset_form = host.HostFilterForm
 
 
-class HostEditView(generic.ObjectEditView):
-    """Host edition view definition"""
+class HostAddView(generic.ObjectEditView):
+    """Host add view definition"""
 
     queryset = Host.objects.all()
-    form = host.HostForm
+    form = host.HostAddForm
 
     def alter_object(self, obj, request, url_args, url_kwargs):
-        if request.method == "POST" and not "pk" in url_kwargs:
-            token = Token(user=self.request.user, write_enabled=True)
+        if request.method == "POST":
+            token = Token(
+                user=self.request.user, write_enabled=True, description="DockerAgent"
+            )
             token.save()
 
             obj.token = token
             obj.netbox_base_url = request.META["HTTP_ORIGIN"]
 
         return super().alter_object(obj, request, url_args, url_kwargs)
+
+
+class HostEditView(generic.ObjectEditView):
+    """Host edition view definition"""
+
+    queryset = Host.objects.all()
+    form = host.HostForm
 
 
 class HostBulkEditView(generic.BulkEditView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-docker-plugin"
-version = "5.1.1"
+version = "5.2.0"
 authors = [
   { name="Vincent Simonin", email="vincent@saashup.com" },
   { name="David Delassus", email="david.jose.delassus@gmail.com" }


### PR DESCRIPTION
## Host ↔ VirtualMachine relationship

- `Host` model: add optional `OneToOneField` to `virtualization.VirtualMachine` (`SET_NULL`, `related_name="docker_hosts"`). One Host may be linked to at most one VirtualMachine; the link is optional on both sides.
- Migration `1044_host_virtual_machine`: `AddField` for the new FK.
- `HostTable`: add linkified `virtual_machine` column (available but not in default columns).
- `HostSerializer` (API): expose `virtual_machine` via `VirtualMachineSerializer`.
- `HostFilterSet` / `filtersets.py`: `virtual_machine_id` filter.
- `HostView` queryset: `prefetch_related` extended with `virtual_machine`.
- `host.html` template: show the linked VM in the Host detail panel.
- `template_content.py` + `virtual_machine_host_table.html`: inject a "Docker Hosts" table on the VirtualMachine detail page using NetBox's `TemplateExtension` mechanism.

## Host add / edit form split

- `HostAddForm` (new, `NetBoxModelForm`): used exclusively at creation time. Fields: `name`, `endpoint`, `virtual_machine`. Tags are suppressed via `__init__` → `self.fields.pop("tags", None)` so that `TagsMixin.__init__` still runs cleanly without a `KeyError` at line 143 of `mixins.py`.
- `HostForm` (existing, `NetBoxModelForm`): used for editing. Gains `virtual_machine` field; keeps `tags`.
- `urls.py`: `hosts/add/` now routes to the new `HostAddView`.
- `HostAddView` (new, `ObjectEditView`): uses `HostAddForm`, always runs the token-creation logic on POST (no dead `not "pk" in url_kwargs` guard needed).
- `HostEditView`: dead `alter_object` override removed (edit URLs always carry a pk so the creation branch could never fire).

## Container validation

- `Container.clean()`: reject saving a Container whose Image has no `ImageID` (i.e. the image has not been pulled yet). Error targets the `image` field: "Image <name> has no ID yet. Pull or refresh it first."

## Tests

- `test_container_validation.py`:
  - `test_that_container_image_must_have_an_id`: expects `ValidationError` when the image has no `ImageID`.
  - `test_that_container_image_with_id_passes_validation`: `clean()` succeeds when `ImageID` is set. Adds `image1_pulled` fixture (`ImageID="sha256:abc123"`).
- `test_host_virtual_machine.py` (new):
  - host without VM is valid (default `None`)
  - host with VM is saved and reloaded correctly
  - OneToOne constraint raises `IntegrityError` (wrapped in `transaction.atomic()` savepoint so the test transaction stays intact)
  - `SET_NULL` on VM deletion nullifies the host FK
  - unlinking sets FK to `None` without deleting either object
  - reverse accessor `vm.docker_host` returns the linked Host